### PR TITLE
Fixed typo in README.md - missing ',' in JSON configuration object

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ require('seneca')()
   .use('seneca-amqp-transport', {
     queues: {
       action: {
-        durable: false
+        durable: false,
         prefix: 'my.namespace'
       }
     }


### PR DESCRIPTION
in example