### PR TITLE
Correct bad plugin options usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,10 +127,13 @@ To override this settings, pass them to the plugin's `.use` declaration:
 ```javascript
 require('seneca')()
   .use('seneca-amqp-transport', {
-    queues: {
-      action: {
-        durable: false,
-        prefix: 'my.namespace'
+    amqp: {
+      queues: {
+        action: {
+          options: {
+            durable: false
+          }
+        }
       }
     }
   });


### PR DESCRIPTION
Documentation bug. Fixes example on overriding plugin options during initialization.